### PR TITLE
generate-raw: Accept a full path in generate, don't hardcode part of it

### DIFF
--- a/crates/generate-raw/src/lib.rs
+++ b/crates/generate-raw/src/lib.rs
@@ -4,8 +4,8 @@ use std::path::Path;
 use std::process::{Command, Stdio};
 use witx::*;
 
-pub fn generate(wasi: &Path) -> String {
-    let doc = witx::load(&[wasi.join("phases/snapshot/witx/wasi_snapshot_preview1.witx")]).unwrap();
+pub fn generate(witx_path: &Path) -> String {
+    let doc = witx::load(&[witx_path]).unwrap();
 
     let mut raw = String::new();
     raw.push_str(

--- a/crates/generate-raw/src/main.rs
+++ b/crates/generate-raw/src/main.rs
@@ -1,8 +1,8 @@
 use std::env;
+use std::path::PathBuf;
 
 fn main() {
-    print!(
-        "{}",
-        generate_raw::generate(env::args_os().nth(1).unwrap().as_ref())
-    );
+    let wasi_dir: PathBuf = env::args_os().nth(1).unwrap().into();
+    let witx_path = wasi_dir.join("phases/snapshot/witx/wasi_snapshot_preview1.witx");
+    print!("{}", generate_raw::generate(&witx_path));
 }

--- a/crates/generate-raw/tests/verify.rs
+++ b/crates/generate-raw/tests/verify.rs
@@ -1,7 +1,8 @@
 #[test]
 fn assert_same_as_src() {
     let actual = include_str!("../../../src/lib.rs");
-    let expected = generate_raw::generate("WASI".as_ref());
+    let expected =
+        generate_raw::generate("WASI/phases/snapshot/witx/wasi_snapshot_preview1.witx".as_ref());
     if actual == expected {
         return;
     }


### PR DESCRIPTION
Make the callers of generate pass a full path to the witx file,
rather than having generate append the path to
wasi_snapshot_preview1.witx. This allows for callers that want to pass a
different path.