### PR TITLE
Support rendering the "handle" witx type, as a u32 for now

### DIFF
--- a/crates/generate-raw/src/lib.rs
+++ b/crates/generate-raw/src/lib.rs
@@ -446,11 +446,8 @@ impl Render for Id {
     }
 }
 
-fn render_handle(src: &mut String, name: &str, h: &HandleDatatype) {
-    drop(src);
-    drop(name);
-    drop(h);
-    panic!("don't know how to render a handle");
+fn render_handle(src: &mut String, name: &str, _h: &HandleDatatype) {
+    src.push_str(&format!("pub type {} = u32;", name.to_camel_case()));
 }
 
 fn rustdoc(docs: &str, dst: &mut String) {


### PR DESCRIPTION
For the moment, a handle just consists of an opaque u32 value.

Tested by rendering the ephemeral version of WASI, which uses handle
for file descriptors.