### PR TITLE
Add `derive(Debug)` to generated struct types.

### DIFF
--- a/crates/generate-raw/src/lib.rs
+++ b/crates/generate-raw/src/lib.rs
@@ -122,7 +122,7 @@ fn render_union(src: &mut String, name: &str, u: &UnionDatatype) {
 
 fn render_struct(src: &mut String, name: &str, s: &StructDatatype) {
     src.push_str("#[repr(C)]\n");
-    src.push_str("#[derive(Copy, Clone)]\n");
+    src.push_str("#[derive(Copy, Clone, Debug)]\n");
     src.push_str(&format!("pub struct {} {{\n", name.to_camel_case()));
     for member in s.members.iter() {
         rustdoc(&member.docs, src);

--- a/src/lib_generated.rs
+++ b/src/lib_generated.rs
@@ -332,7 +332,7 @@ pub const RIGHTS_POLL_FD_READWRITE: Rights = 0x8000000;
 pub const RIGHTS_SOCK_SHUTDOWN: Rights = 0x10000000;
 pub type Fd = u32;
 #[repr(C)]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, Debug)]
 pub struct Iovec {
     /// The address of the buffer to be filled.
     pub buf: *mut u8,
@@ -340,7 +340,7 @@ pub struct Iovec {
     pub buf_len: Size,
 }
 #[repr(C)]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, Debug)]
 pub struct Ciovec {
     /// The address of the buffer to be written.
     pub buf: *const u8,
@@ -378,7 +378,7 @@ pub const FILETYPE_SOCKET_STREAM: Filetype = 6;
 /// The file refers to a symbolic link inode.
 pub const FILETYPE_SYMBOLIC_LINK: Filetype = 7;
 #[repr(C)]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, Debug)]
 pub struct Dirent {
     /// The offset of the next directory entry stored in this directory.
     pub d_next: Dircookie,
@@ -416,7 +416,7 @@ pub const FDFLAGS_RSYNC: Fdflags = 0x8;
 /// may also synchronously update the file's metadata.
 pub const FDFLAGS_SYNC: Fdflags = 0x10;
 #[repr(C)]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, Debug)]
 pub struct Fdstat {
     /// File type.
     pub fs_filetype: Filetype,
@@ -452,7 +452,7 @@ pub const OFLAGS_EXCL: Oflags = 0x4;
 pub const OFLAGS_TRUNC: Oflags = 0x8;
 pub type Linkcount = u64;
 #[repr(C)]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, Debug)]
 pub struct Filestat {
     /// Device ID of device containing the file.
     pub dev: Device,
@@ -486,7 +486,7 @@ pub type Eventrwflags = u16;
 /// The peer of this socket has closed or disconnected.
 pub const EVENTRWFLAGS_FD_READWRITE_HANGUP: Eventrwflags = 0x1;
 #[repr(C)]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, Debug)]
 pub struct EventFdReadwrite {
     /// The number of bytes available for reading or writing.
     pub nbytes: Filesize,
@@ -514,7 +514,7 @@ pub type Subclockflags = u16;
 /// current time value of clock `subscription_clock::id`.
 pub const SUBCLOCKFLAGS_SUBSCRIPTION_CLOCK_ABSTIME: Subclockflags = 0x1;
 #[repr(C)]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, Debug)]
 pub struct SubscriptionClock {
     /// The clock against which to compare the timestamp.
     pub id: Clockid,
@@ -527,7 +527,7 @@ pub struct SubscriptionClock {
     pub flags: Subclockflags,
 }
 #[repr(C)]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, Debug)]
 pub struct SubscriptionFdReadwrite {
     /// The file descriptor on which to wait for it to become ready for reading or writing.
     pub file_descriptor: Fd,
@@ -547,7 +547,6 @@ pub struct SubscriptionU {
 }
 
 #[repr(C)]
-#[derive(Copy, Clone)]
 pub struct Subscription {
     /// User-provided value that is attached to the subscription in the
     /// implementation and returned through `event::userdata`.
@@ -668,7 +667,7 @@ pub type Preopentype = u8;
 /// A pre-opened directory.
 pub const PREOPENTYPE_DIR: Preopentype = 0;
 #[repr(C)]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, Debug)]
 pub struct PrestatDir {
     /// The length of the directory name for use with `fd_prestat_dir_name`.
     pub pr_name_len: Size,
@@ -679,7 +678,7 @@ pub union PrestatU {
     pub dir: PrestatDir,
 }
 #[repr(C)]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, Debug)]
 pub struct Prestat {
     pub tag: Preopentype,
     pub u: PrestatU,


### PR DESCRIPTION
Fixes #34 and #35.