### PR TITLE
FF WASI submodule and update the machinery

### DIFF
--- a/crates/generate-raw/Cargo.toml
+++ b/crates/generate-raw/Cargo.toml
@@ -9,3 +9,8 @@ edition = "2018"
 [dependencies]
 heck = "0.3"
 witx = { path = "WASI/tools/witx" }
+cfg-if = "0.1"
+
+[features]
+default = []
+multi-module = []

--- a/crates/generate-raw/src/lib.rs
+++ b/crates/generate-raw/src/lib.rs
@@ -226,9 +226,13 @@ impl Render for BuiltinType {
             BuiltinType::S64 => src.push_str("i64"),
             BuiltinType::F32 => src.push_str("f32"),
             BuiltinType::F64 => src.push_str("f64"),
-            BuiltinType::USize => src.push_str("usize"),
+            BuiltinType::USize => {
+                // TODO verify handling of USize
+                src.push_str("usize")
+            }
             BuiltinType::Char8 => {
-                // TODO handle Char8
+                // TODO verify handling of Char8
+                src.push_str("char")
             }
         }
     }

--- a/crates/generate-raw/src/lib.rs
+++ b/crates/generate-raw/src/lib.rs
@@ -278,7 +278,18 @@ fn render_highlevel(func: &InterfaceFunc, module: &str, src: &mut String) {
     // descriptors, which are effectively forgeable and danglable raw pointers
     // into the file descriptor address space.
     src.push_str("pub unsafe fn ");
-    src.push_str(&rust_name);
+
+    // TODO workout how to handle wasi-ephemeral which introduces multiple
+    // WASI modules into the picture. For now, feature-gate it, and if we're
+    // compiling ephmeral bindings, prefix wrapper syscall with module name.
+    cfg_if::cfg_if! {
+        if #[cfg(feature = "multi-module")] {
+            src.push_str(&[module, &rust_name].join("_"));
+        } else {
+            src.push_str(&rust_name);
+        }
+    }
+
     src.push_str("(");
     for param in func.params.iter() {
         param.name.render(src);

--- a/crates/generate-raw/src/lib.rs
+++ b/crates/generate-raw/src/lib.rs
@@ -63,9 +63,7 @@ impl Render for NamedType {
             TypeRef::Value(ty) => match &**ty {
                 Type::Enum(e) => render_enum(src, name, e),
                 Type::Flags(f) => render_flags(src, name, f),
-                Type::Int(_) => {
-                    // TODO handle Int
-                }
+                Type::Int(c) => render_const(src, name, c),
                 Type::Struct(s) => render_struct(src, name, s),
                 Type::Union(u) => render_union(src, name, u),
                 Type::Handle(h) => render_handle(src, name, h),
@@ -76,6 +74,23 @@ impl Render for NamedType {
             },
             TypeRef::Name(_nt) => render_alias(src, name, &self.tref),
         }
+    }
+}
+
+// TODO verify this is correct way of handling IntDatatype
+fn render_const(src: &mut String, name: &str, c: &IntDatatype) {
+    src.push_str(&format!("pub type {} = ", name.to_camel_case()));
+    c.repr.render(src);
+    src.push_str(";\n");
+    for r#const in c.consts.iter() {
+        rustdoc(&r#const.docs, src);
+        src.push_str(&format!(
+            "pub const {}_{}: {} = {};",
+            name.to_shouty_snake_case(),
+            r#const.name.as_str().to_shouty_snake_case(),
+            name.to_camel_case(),
+            r#const.value
+        ));
     }
 }
 

--- a/crates/generate-raw/src/lib.rs
+++ b/crates/generate-raw/src/lib.rs
@@ -4,8 +4,8 @@ use std::path::Path;
 use std::process::{Command, Stdio};
 use witx::*;
 
-pub fn generate(witx_path: &Path) -> String {
-    let doc = witx::load(&[witx_path]).unwrap();
+pub fn generate<P: AsRef<Path>>(witx_paths: &[P]) -> String {
+    let doc = witx::load(witx_paths).unwrap();
 
     let mut raw = String::new();
     raw.push_str(
@@ -59,19 +59,22 @@ trait Render {
 impl Render for NamedType {
     fn render(&self, src: &mut String) {
         let name = self.name.as_str();
-        match &self.dt {
+        match &self.tref {
             TypeRef::Value(ty) => match &**ty {
                 Type::Enum(e) => render_enum(src, name, e),
                 Type::Flags(f) => render_flags(src, name, f),
+                Type::Int(_) => {
+                    // TODO handle Int
+                }
                 Type::Struct(s) => render_struct(src, name, s),
                 Type::Union(u) => render_union(src, name, u),
                 Type::Handle(h) => render_handle(src, name, h),
                 Type::Array { .. }
                 | Type::Pointer { .. }
                 | Type::ConstPointer { .. }
-                | Type::Builtin { .. } => render_alias(src, name, &self.dt),
+                | Type::Builtin { .. } => render_alias(src, name, &self.tref),
             },
-            TypeRef::Name(_nt) => render_alias(src, name, &self.dt),
+            TypeRef::Name(_nt) => render_alias(src, name, &self.tref),
         }
     }
 }
@@ -223,6 +226,10 @@ impl Render for BuiltinType {
             BuiltinType::S64 => src.push_str("i64"),
             BuiltinType::F32 => src.push_str("f32"),
             BuiltinType::F64 => src.push_str("f64"),
+            BuiltinType::USize => src.push_str("usize"),
+            BuiltinType::Char8 => {
+                // TODO handle Char8
+            }
         }
     }
 }

--- a/crates/generate-raw/src/lib.rs
+++ b/crates/generate-raw/src/lib.rs
@@ -265,7 +265,8 @@ impl Render for Module {
 }
 
 fn render_highlevel(func: &InterfaceFunc, module: &str, src: &mut String) {
-    let rust_name = func.name.as_str().to_snake_case();
+    let mut rust_name = String::new();
+    func.name.render(&mut rust_name);
     rustdoc(&func.docs, src);
     rustdoc_params(&func.params, "Parameters", src);
     rustdoc_params(&func.results, "Return", src);
@@ -374,7 +375,7 @@ impl Render for InterfaceFunc {
             src.push_str("\"]\n");
         }
         src.push_str("pub fn ");
-        src.push_str(&self.name.as_str().to_snake_case());
+        self.name.render(src);
         src.push_str("(");
         for param in self.params.iter() {
             param.render(src);
@@ -452,6 +453,7 @@ impl Render for Id {
         match self.as_str() {
             "in" => src.push_str("r#in"),
             "type" => src.push_str("r#type"),
+            "yield" => src.push_str("r#yield"),
             s => src.push_str(s),
         }
     }

--- a/crates/generate-raw/src/lib.rs
+++ b/crates/generate-raw/src/lib.rs
@@ -267,6 +267,7 @@ impl Render for Module {
 fn render_highlevel(func: &InterfaceFunc, module: &str, src: &mut String) {
     let mut rust_name = String::new();
     func.name.render(&mut rust_name);
+    let rust_name = rust_name.to_snake_case();
     rustdoc(&func.docs, src);
     rustdoc_params(&func.params, "Parameters", src);
     rustdoc_params(&func.results, "Return", src);
@@ -375,7 +376,9 @@ impl Render for InterfaceFunc {
             src.push_str("\"]\n");
         }
         src.push_str("pub fn ");
-        self.name.render(src);
+        let mut name = String::new();
+        self.name.render(&mut name);
+        src.push_str(&name.to_snake_case());
         src.push_str("(");
         for param in self.params.iter() {
             param.render(src);

--- a/crates/generate-raw/src/main.rs
+++ b/crates/generate-raw/src/main.rs
@@ -4,5 +4,5 @@ use std::path::PathBuf;
 fn main() {
     let wasi_dir: PathBuf = env::args_os().nth(1).unwrap().into();
     let witx_path = wasi_dir.join("phases/snapshot/witx/wasi_snapshot_preview1.witx");
-    print!("{}", generate_raw::generate(&witx_path));
+    print!("{}", generate_raw::generate(&[witx_path]));
 }

--- a/crates/generate-raw/tests/verify.rs
+++ b/crates/generate-raw/tests/verify.rs
@@ -2,7 +2,7 @@
 fn assert_same_as_src() {
     let actual = include_str!("../../../src/lib_generated.rs");
     let expected =
-        generate_raw::generate("WASI/phases/snapshot/witx/wasi_snapshot_preview1.witx".as_ref());
+        generate_raw::generate(&["WASI/phases/snapshot/witx/wasi_snapshot_preview1.witx"]);
     if actual == expected {
         return;
     }

--- a/crates/wasi-ephemeral/Cargo.toml
+++ b/crates/wasi-ephemeral/Cargo.toml
@@ -11,7 +11,7 @@ keywords = ["webassembly", "wasm"]
 repository = "https://github.com/bytecodealliance/wasi"
 
 [build-dependencies]
-generate-raw = { path = "../generate-raw" }
+generate-raw = { path = "../generate-raw", features = ["multi-module"] }
 
 [features]
 default = ["std"]

--- a/crates/wasi-ephemeral/build.rs
+++ b/crates/wasi-ephemeral/build.rs
@@ -17,9 +17,8 @@ fn main() {
     let witx_paths: Vec<_> = WITX_MODULES
         .iter()
         .map(|x| {
-            let mut p = root.join(&["wasi_ephemeral_", x].join("")).to_owned();
-            p.set_extension("witx");
-            p
+            root.join(&["wasi_ephemeral_", x, ".witx"].join(""))
+                .to_owned()
         })
         .collect();
     let out = generate_raw::generate(&witx_paths);

--- a/src/lib_generated.rs
+++ b/src/lib_generated.rs
@@ -262,7 +262,7 @@ pub(crate) fn strerror(code: u16) -> &'static str {
 pub type Rights = u64;
 /// The right to invoke `fd_datasync`.
 /// If `path_open` is set, includes the right to invoke
-/// `path_open` with `fdflag::dsync`.
+/// `path_open` with `fdflags::dsync`.
 pub const RIGHTS_FD_DATASYNC: Rights = 0x1;
 /// The right to invoke `fd_read` and `sock_recv`.
 /// If `rights::fd_seek` is set, includes the right to invoke `fd_pread`.
@@ -273,10 +273,10 @@ pub const RIGHTS_FD_SEEK: Rights = 0x4;
 pub const RIGHTS_FD_FDSTAT_SET_FLAGS: Rights = 0x8;
 /// The right to invoke `fd_sync`.
 /// If `path_open` is set, includes the right to invoke
-/// `path_open` with `fdflag::rsync` and `fdflag::dsync`.
+/// `path_open` with `fdflags::rsync` and `fdflags::dsync`.
 pub const RIGHTS_FD_SYNC: Rights = 0x10;
 /// The right to invoke `fd_seek` in such a way that the file offset
-/// remains unaltered (i.e., `WHENCE_CUR` with offset zero), or to
+/// remains unaltered (i.e., `whence::cur` with offset zero), or to
 /// invoke `fd_tell`.
 pub const RIGHTS_FD_TELL: Rights = 0x20;
 /// The right to invoke `fd_write` and `sock_send`.
@@ -430,13 +430,13 @@ pub struct Fdstat {
 }
 pub type Device = u64;
 pub type Fstflags = u16;
-/// Adjust the last data access timestamp to the value stored in `filestat::st_atim`.
+/// Adjust the last data access timestamp to the value stored in `filestat::atim`.
 pub const FSTFLAGS_ATIM: Fstflags = 0x1;
-/// Adjust the last data access timestamp to the time of clock `clock::realtime`.
+/// Adjust the last data access timestamp to the time of clock `clockid::realtime`.
 pub const FSTFLAGS_ATIM_NOW: Fstflags = 0x2;
-/// Adjust the last data modification timestamp to the value stored in `filestat::st_mtim`.
+/// Adjust the last data modification timestamp to the value stored in `filestat::mtim`.
 pub const FSTFLAGS_MTIM: Fstflags = 0x4;
-/// Adjust the last data modification timestamp to the time of clock `clock::realtime`.
+/// Adjust the last data modification timestamp to the time of clock `clockid::realtime`.
 pub const FSTFLAGS_MTIM_NOW: Fstflags = 0x8;
 pub type Lookupflags = u32;
 /// As long as the resolved path corresponds to a symbolic link, it is expanded.
@@ -473,13 +473,13 @@ pub struct Filestat {
 }
 pub type Userdata = u64;
 pub type Eventtype = u8;
-/// The time value of clock `subscription::u.clock.clock_id` has
-/// reached timestamp `subscription::u.clock.timeout`.
+/// The time value of clock `subscription_clock::id` has
+/// reached timestamp `subscription_clock::timeout`.
 pub const EVENTTYPE_CLOCK: Eventtype = 0;
-/// File descriptor `subscription::u.fd_readwrite.fd` has data
+/// File descriptor `subscription_fd_readwrite::file_descriptor` has data
 /// available for reading. This event always triggers for regular files.
 pub const EVENTTYPE_FD_READ: Eventtype = 1;
-/// File descriptor `subscription::u.fd_readwrite.fd` has capacity
+/// File descriptor `subscription_fd_readwrite::file_descriptor` has capacity
 /// available for writing. This event always triggers for regular files.
 pub const EVENTTYPE_FD_WRITE: Eventtype = 2;
 pub type Eventrwflags = u16;
@@ -513,10 +513,10 @@ pub struct Event {
 }
 pub type Subclockflags = u16;
 /// If set, treat the timestamp provided in
-/// `subscription::u.clock.timeout` as an absolute timestamp of clock
-/// `subscription::u.clock.clock_id.` If clear, treat the timestamp
-/// provided in `subscription::u.clock.timeout` relative to the
-/// current time value of clock `subscription::u.clock.clock_id.`
+/// `subscription_clock::timeout` as an absolute timestamp of clock
+/// `subscription_clock::id`. If clear, treat the timestamp
+/// provided in `subscription_clock::timeout` relative to the
+/// current time value of clock `subscription_clock::id`.
 pub const SUBCLOCKFLAGS_SUBSCRIPTION_CLOCK_ABSTIME: Subclockflags = 0x1;
 #[repr(C)]
 #[derive(Copy, Clone)]
@@ -689,7 +689,7 @@ pub struct Prestat {
     pub u: PrestatU,
 }
 /// Read command-line argument data.
-/// The size of the array should match that returned by `wasi_args_sizes_get()`
+/// The size of the array should match that returned by `args_sizes_get`
 pub unsafe fn args_get(argv: *mut *mut u8, argv_buf: *mut u8) -> Result<()> {
     let rc = wasi_snapshot_preview1::args_get(argv, argv_buf);
     if let Some(err) = Error::from_raw_error(rc) {
@@ -717,7 +717,7 @@ pub unsafe fn args_sizes_get() -> Result<(Size, Size)> {
 }
 
 /// Read environment variable data.
-/// The sizes of the buffers should match that returned by `environ.sizes_get()`.
+/// The sizes of the buffers should match that returned by `environ_sizes_get`.
 pub unsafe fn environ_get(environ: *mut *mut u8, environ_buf: *mut u8) -> Result<()> {
     let rc = wasi_snapshot_preview1::environ_get(environ, environ_buf);
     if let Some(err) = Error::from_raw_error(rc) {
@@ -746,7 +746,8 @@ pub unsafe fn environ_sizes_get() -> Result<(Size, Size)> {
 }
 
 /// Return the resolution of a clock.
-/// Implementations are required to provide a non-zero value for supported clocks. For unsupported clocks, return `WASI_EINVAL`
+/// Implementations are required to provide a non-zero value for supported clocks. For unsupported clocks,
+/// return `errno::inval`.
 /// Note: This is similar to `clock_getres` in POSIX.
 ///
 /// ## Parameters
@@ -874,7 +875,7 @@ pub unsafe fn fd_fdstat_set_flags(fd: Fd, flags: Fdflags) -> Result<()> {
 }
 
 /// Adjust the rights associated with a file descriptor.
-/// This can only be used to remove rights, and returns `ENOTCAPABLE` if called in a way that would attempt to add rights
+/// This can only be used to remove rights, and returns `errno::notcapable` if called in a way that would attempt to add rights
 ///
 /// ## Parameters
 ///
@@ -1279,7 +1280,7 @@ pub unsafe fn path_link(
 ///
 /// * `dirflags` - Flags determining the method of how the path is resolved.
 /// * `path` - The relative path of the file or directory to open, relative to the
-///   `dirfd` directory.
+///   `path_open::fd` directory.
 /// * `oflags` - The method by which to open the file.
 /// * `fs_rights_base` - The initial rights of the newly created file descriptor. The
 ///   implementation is allowed to return a file descriptor with fewer rights
@@ -1349,7 +1350,7 @@ pub unsafe fn path_readlink(fd: Fd, path: &str, buf: *mut u8, buf_len: Size) -> 
 }
 
 /// Remove a directory.
-/// Return `ENOTEMPTY` if the directory is not empty.
+/// Return `errno::notempty` if the directory is not empty.
 /// Note: This is similar to `unlinkat(fd, path, AT_REMOVEDIR)` in POSIX.
 ///
 /// ## Parameters
@@ -1411,7 +1412,7 @@ pub unsafe fn path_symlink(old_path: &str, fd: Fd, new_path: &str) -> Result<()>
 }
 
 /// Unlink a file.
-/// Return `EISDIR` if the path refers to a directory.
+/// Return `errno::isdir` if the path refers to a directory.
 /// Note: This is similar to `unlinkat(fd, path, 0)` in POSIX.
 ///
 /// ## Parameters
@@ -1586,17 +1587,18 @@ pub mod wasi_snapshot_preview1 {
     #[link(wasm_import_module = "wasi_snapshot_preview1")]
     extern "C" {
         /// Read command-line argument data.
-        /// The size of the array should match that returned by `wasi_args_sizes_get()`
+        /// The size of the array should match that returned by `args_sizes_get`
         pub fn args_get(argv: *mut *mut u8, argv_buf: *mut u8) -> Errno;
         /// Return command-line argument data sizes.
         pub fn args_sizes_get(argc: *mut Size, argv_buf_size: *mut Size) -> Errno;
         /// Read environment variable data.
-        /// The sizes of the buffers should match that returned by `environ.sizes_get()`.
+        /// The sizes of the buffers should match that returned by `environ_sizes_get`.
         pub fn environ_get(environ: *mut *mut u8, environ_buf: *mut u8) -> Errno;
         /// Return command-line argument data sizes.
         pub fn environ_sizes_get(argc: *mut Size, argv_buf_size: *mut Size) -> Errno;
         /// Return the resolution of a clock.
-        /// Implementations are required to provide a non-zero value for supported clocks. For unsupported clocks, return `WASI_EINVAL`
+        /// Implementations are required to provide a non-zero value for supported clocks. For unsupported clocks,
+        /// return `errno::inval`.
         /// Note: This is similar to `clock_getres` in POSIX.
         pub fn clock_res_get(id: Clockid, resolution: *mut Timestamp) -> Errno;
         /// Return the time value of a clock.
@@ -1621,7 +1623,7 @@ pub mod wasi_snapshot_preview1 {
         /// Note: This is similar to `fcntl(fd, F_SETFL, flags)` in POSIX.
         pub fn fd_fdstat_set_flags(fd: Fd, flags: Fdflags) -> Errno;
         /// Adjust the rights associated with a file descriptor.
-        /// This can only be used to remove rights, and returns `ENOTCAPABLE` if called in a way that would attempt to add rights
+        /// This can only be used to remove rights, and returns `errno::notcapable` if called in a way that would attempt to add rights
         pub fn fd_fdstat_set_rights(
             fd: Fd,
             fs_rights_base: Rights,
@@ -1775,7 +1777,7 @@ pub mod wasi_snapshot_preview1 {
             bufused: *mut Size,
         ) -> Errno;
         /// Remove a directory.
-        /// Return `ENOTEMPTY` if the directory is not empty.
+        /// Return `errno::notempty` if the directory is not empty.
         /// Note: This is similar to `unlinkat(fd, path, AT_REMOVEDIR)` in POSIX.
         pub fn path_remove_directory(fd: Fd, path_ptr: *const u8, path_len: usize) -> Errno;
         /// Rename a file or directory.
@@ -1798,7 +1800,7 @@ pub mod wasi_snapshot_preview1 {
             new_path_len: usize,
         ) -> Errno;
         /// Unlink a file.
-        /// Return `EISDIR` if the path refers to a directory.
+        /// Return `errno::isdir` if the path refers to a directory.
         /// Note: This is similar to `unlinkat(fd, path, 0)` in POSIX.
         pub fn path_unlink_file(fd: Fd, path_ptr: *const u8, path_len: usize) -> Errno;
         /// Concurrently poll for the occurrence of a set of events.


### PR DESCRIPTION
This commit fast-forwards the `WASI` submodule and updates the
relevant the machinery. It also updates `generate_raw::generate`
fn to accept a slice in preparation for multi-module `wasi_ephemeral`.

Changes introduced by this PR:
* change signature of `generate_raw::generate` from `fn generate(&Path)` to `fn <P: AsRef<Path>>generate(&[P])`; this effectively is needed if we want to be able to generate bindings from multi-module snapshots such as `ephemeral`.
* add feature `multi-module` to `generate` crate which serves as a workaround for avoiding name clashes for syscalls that are a very present danger introduced in multi-module `ephemeral` snapshot; this "hack", when the feature is enabled, prepends the Wasm module name to the syscall's name when generating Rust wrappers. This is a temporary solution until we figure out how to handle it better.
* escape syscall names; in particular, due to multi-modularity of `ephemeral`, we can now encounter reserved words used as syscall names. `yield` is such an example.
* add draft implementation for `Char8` and `USize` builtins, and a draft implementation of `IntDatatype` which currently is used as the underlying representation of `Dircookie`.

cc @pchickey if you rebase #41 on top of this PR, this should hopefully fix the CI for you, and make your PR less cluttered.

EDIT: forgot to mention that `IntDataype` is currently generated similarly to how `FlagsDatatype`. For example:

```rust
pub type Dircookie = u64;
pub const DIRCOOKIE_START: Dircookie = 0;
```