### PR TITLE
Allow generate-raw to run single witx files

### DIFF
--- a/crates/witx-bindgen/README.md
+++ b/crates/witx-bindgen/README.md
@@ -1,0 +1,9 @@
+# witx-bindgen
+
+Generate Rust code matching a witx interface.
+
+### Use
+
+```
+cargo run [path to witx file]
+```

--- a/crates/witx-bindgen/src/main.rs
+++ b/crates/witx-bindgen/src/main.rs
@@ -2,7 +2,6 @@ use std::env;
 use std::path::PathBuf;
 
 fn main() {
-    let wasi_dir: PathBuf = env::args_os().nth(1).unwrap().into();
-    let witx_path = wasi_dir.join("phases/snapshot/witx/wasi_snapshot_preview1.witx");
+    let witx_path: PathBuf = env::args_os().nth(1).unwrap().into();
     print!("{}", witx_bindgen::generate(&[witx_path]));
 }

--- a/crates/witx-bindgen/tests/verify.rs
+++ b/crates/witx-bindgen/tests/verify.rs
@@ -1,19 +1,20 @@
 #[test]
 fn assert_same_as_src() {
     let actual = include_str!("../../../src/lib_generated.rs");
-    let expected =
-        witx_bindgen::generate(&["WASI/phases/snapshot/witx/wasi_snapshot_preview1.witx"]);
+    let witx_path = "WASI/phases/snapshot/witx/wasi_snapshot_preview1.witx";
+    let expected = witx_bindgen::generate(&[witx_path]);
     if actual == expected {
         return;
     }
     panic!(
         "
 
-the generate `raw.rs` does not match the actual source `raw.rs`, it's
+the generated `raw.rs` does not match the actual source `raw.rs`, it's
 recommended to run this command from the root of the repository:
 
-    cargo run -p witx-bindgen crates/witx-bindgen/WASI > src/lib_generated.rs
+    cargo run -p witx-bindgen crates/witx-bindgen/{} > src/lib_generated.rs
 
-"
+",
+        witx_path
     );
 }


### PR DESCRIPTION
Previously, the witx path was hard-coded to a snapshot but this change allows me to use it for wasi-nn.