### PR TITLE
ci: install rustfmt (used by generate-raw crate)

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -13,7 +13,7 @@ jobs:
       with:
         submodules: true
     - name: Install Rust
-      run: rustup update ${{ matrix.rust }} && rustup default ${{ matrix.rust }}
+      run: rustup update ${{ matrix.rust }} && rustup default ${{ matrix.rust }} && rustup component add rustfmt
     - run: rustup target add wasm32-wasi
     - run: cargo build
     - run: cargo build --no-default-features


### PR DESCRIPTION
This should fix errors like those observed in https://github.com/bytecodealliance/wasi/pull/46/checks?check_run_id=1009925040#step:9:99.