### PR TITLE
Generate lifetime parameter explicitly for aliased PointerLengthPair

### DIFF
--- a/crates/witx-bindgen/src/lib.rs
+++ b/crates/witx-bindgen/src/lib.rs
@@ -222,6 +222,9 @@ impl Render for TypeRef {
         match self {
             TypeRef::Name(t) => {
                 src.push_str(&t.name.as_str().to_camel_case());
+                if t.type_().passed_by() == TypePassedBy::PointerLengthPair {
+                    src.push_str("<'_>");
+                }
             }
             TypeRef::Value(v) => match &**v {
                 Type::Builtin(t) => t.render(src),

--- a/src/lib_generated.rs
+++ b/src/lib_generated.rs
@@ -955,7 +955,7 @@ pub unsafe fn fd_filestat_set_times(
 /// ## Return
 ///
 /// * `nread` - The number of bytes read.
-pub unsafe fn fd_pread(fd: Fd, iovs: IovecArray, offset: Filesize) -> Result<Size> {
+pub unsafe fn fd_pread(fd: Fd, iovs: IovecArray<'_>, offset: Filesize) -> Result<Size> {
     let mut nread = MaybeUninit::uninit();
     let rc =
         wasi_snapshot_preview1::fd_pread(fd, iovs.as_ptr(), iovs.len(), offset, nread.as_mut_ptr());
@@ -1006,7 +1006,7 @@ pub unsafe fn fd_prestat_dir_name(fd: Fd, path: *mut u8, path_len: Size) -> Resu
 /// ## Return
 ///
 /// * `nwritten` - The number of bytes written.
-pub unsafe fn fd_pwrite(fd: Fd, iovs: CiovecArray, offset: Filesize) -> Result<Size> {
+pub unsafe fn fd_pwrite(fd: Fd, iovs: CiovecArray<'_>, offset: Filesize) -> Result<Size> {
     let mut nwritten = MaybeUninit::uninit();
     let rc = wasi_snapshot_preview1::fd_pwrite(
         fd,
@@ -1032,7 +1032,7 @@ pub unsafe fn fd_pwrite(fd: Fd, iovs: CiovecArray, offset: Filesize) -> Result<S
 /// ## Return
 ///
 /// * `nread` - The number of bytes read.
-pub unsafe fn fd_read(fd: Fd, iovs: IovecArray) -> Result<Size> {
+pub unsafe fn fd_read(fd: Fd, iovs: IovecArray<'_>) -> Result<Size> {
     let mut nread = MaybeUninit::uninit();
     let rc = wasi_snapshot_preview1::fd_read(fd, iovs.as_ptr(), iovs.len(), nread.as_mut_ptr());
     if let Some(err) = Error::from_raw_error(rc) {
@@ -1149,7 +1149,7 @@ pub unsafe fn fd_tell(fd: Fd) -> Result<Filesize> {
 /// ## Return
 ///
 /// * `nwritten` - The number of bytes written.
-pub unsafe fn fd_write(fd: Fd, iovs: CiovecArray) -> Result<Size> {
+pub unsafe fn fd_write(fd: Fd, iovs: CiovecArray<'_>) -> Result<Size> {
     let mut nwritten = MaybeUninit::uninit();
     let rc = wasi_snapshot_preview1::fd_write(fd, iovs.as_ptr(), iovs.len(), nwritten.as_mut_ptr());
     if let Some(err) = Error::from_raw_error(rc) {
@@ -1520,7 +1520,11 @@ pub unsafe fn random_get(buf: *mut u8, buf_len: Size) -> Result<()> {
 ///
 /// * `ro_datalen` - Number of bytes stored in ri_data.
 /// * `ro_flags` - Message flags.
-pub unsafe fn sock_recv(fd: Fd, ri_data: IovecArray, ri_flags: Riflags) -> Result<(Size, Roflags)> {
+pub unsafe fn sock_recv(
+    fd: Fd,
+    ri_data: IovecArray<'_>,
+    ri_flags: Riflags,
+) -> Result<(Size, Roflags)> {
     let mut ro_datalen = MaybeUninit::uninit();
     let mut ro_flags = MaybeUninit::uninit();
     let rc = wasi_snapshot_preview1::sock_recv(
@@ -1550,7 +1554,7 @@ pub unsafe fn sock_recv(fd: Fd, ri_data: IovecArray, ri_flags: Riflags) -> Resul
 /// ## Return
 ///
 /// * `so_datalen` - Number of bytes transmitted.
-pub unsafe fn sock_send(fd: Fd, si_data: CiovecArray, si_flags: Siflags) -> Result<Size> {
+pub unsafe fn sock_send(fd: Fd, si_data: CiovecArray<'_>, si_flags: Siflags) -> Result<Size> {
     let mut so_datalen = MaybeUninit::uninit();
     let rc = wasi_snapshot_preview1::sock_send(
         fd,


### PR DESCRIPTION
This PR makes tiny improvement for the generated `src/lib_generated.rs` from witx.
Currently generated code lacks explicit lifetime parameter when an aliased type is referred as an argument, which is [encouraged to put explicitly in Rust 2018](https://doc.rust-lang.org/edition-guide/rust-2018/ownership-and-lifetimes/the-anonymous-lifetime.html#more-details).

In fact these optional warnings prevents me from compiling rust-lang/rust with pointing `wasi` dependency to my local copy by following errors.

```
error: hidden lifetime parameters in types are deprecated
   --> /Users/masked/wasi/src/lib_generated.rs:958:38
    |
958 | pub unsafe fn fd_pread(fd: Fd, iovs: IovecArray, offset: Filesize) -> Result<Size> {
    |                                      ^^^^^^^^^^- help: indicate the anonymous lifetime: `<'_>`
    |
    = note: `-D elided-lifetimes-in-paths` implied by `-D warnings`

error: hidden lifetime parameters in types are deprecated
    --> /Users/masked/wasi/src/lib_generated.rs:1009:39
     |
1009 | pub unsafe fn fd_pwrite(fd: Fd, iovs: CiovecArray, offset: Filesize) -> Result<Size> {
     |                                       ^^^^^^^^^^^- help: indicate the anonymous lifetime: `<'_>`

error: hidden lifetime parameters in types are deprecated
    --> /Users/masked/wasi/src/lib_generated.rs:1035:37
     |
1035 | pub unsafe fn fd_read(fd: Fd, iovs: IovecArray) -> Result<Size> {
     |                                     ^^^^^^^^^^- help: indicate the anonymous lifetime: `<'_>`
...
```
