### PR TITLE
Add the repository so people know where to look for the source code

### DIFF
--- a/crates/witx-bindgen/Cargo.toml
+++ b/crates/witx-bindgen/Cargo.toml
@@ -5,6 +5,7 @@ authors = ["The Cranelift Project Developers"]
 license = "Apache-2.0 WITH LLVM-exception OR Apache-2.0 OR MIT"
 edition = "2018"
 description = "Utility to turn witx files into Rust source code bindings"
+repository = "https://github.com/bytecodealliance/wasi/tree/main/crates/witx-bindgen"
 
 [dependencies]
 heck = "0.3"


### PR DESCRIPTION
Disclaimer: this is a via-github en-passant PR, nothing is actually tested but hopefully it'll add the repository link to crates.io so other people don't have to also use the github search to figure out where the source code lives.