### PR TITLE
Update to the latest WASI snapshot1 and release 0.10.3

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wasi"
-version = "0.10.2+wasi-snapshot-preview1"
+version = "0.10.3+wasi-snapshot-preview1"
 authors = ["The Cranelift Project Developers"]
 license = "Apache-2.0 WITH LLVM-exception OR Apache-2.0 OR MIT"
 description = "Experimental WASI API bindings for Rust"


### PR DESCRIPTION
The most notable change here is the addition of the `sock_accept()` call.

https://github.com/WebAssembly/WASI/pull/458