### PR TITLE
Add a suffix to the metadata section for component types

### DIFF
--- a/ci/regenerate.sh
+++ b/ci/regenerate.sh
@@ -2,7 +2,7 @@
 
 set -ex
 
-wit-bindgen rust wit --out-dir src --std-feature
+wit-bindgen rust wit --out-dir src --std-feature --type-section-suffix rust-wasi-from-crates-io
 
 # rustfmt chokes on the raw output of wit-bindgen right now due to trailling
 # whitespace (unsure as to why), so format it with some options first to get it

--- a/src/bindings.rs
+++ b/src/bindings.rs
@@ -15354,7 +15354,7 @@ pub mod wasi {
 }
 
 #[cfg(target_arch = "wasm32")]
-#[link_section = "component-type:bindings"]
+#[link_section = "component-type:bindingsrust-wasi-from-crates-io"]
 #[doc(hidden)]
 pub static __WIT_BINDGEN_COMPONENT_TYPE: [u8; 15607] = [
     0, 97, 115, 109, 13, 0, 1, 0, 0, 25, 22, 119, 105, 116, 45, 99, 111, 109, 112, 111, 110, 101,


### PR DESCRIPTION
This will help prevent clashes with any other world called "bindings" by ensuring that wasm-ld doesn't concatenate sections and corrupt the internal contents.