### PR TITLE
Use `--locked` when installing `wit-bindgen-cli`

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -52,6 +52,6 @@ jobs:
     - uses: actions/checkout@v4
     - name: Install Rust
       run: rustup update stable && rustup default stable
-    - run: cargo install wit-bindgen-cli@0.19.1
+    - run: cargo install wit-bindgen-cli@0.19.2 --locked
     - run: ./ci/regenerate.sh
     - run: git diff --exit-code


### PR DESCRIPTION
Avoid minor patch updates for versions of dependencies to ensure that the output stays consistent over time for CI checks.