### PR TITLE
Delete unused rustfmt-bindings.toml file.

### DIFF
--- a/ci/rustfmt-bindings.toml
+++ b/ci/rustfmt-bindings.toml
@@ -1,2 +1,0 @@
-max_width = 100
-tab_spaces = 2


### PR DESCRIPTION
As of #81, this rustfmt-bindings.toml file is no longer used.