### PR TITLE
Rename the repository from `wasi` to `wasi-rs`.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ description = "WASI API bindings for Rust"
 edition = "2021"
 categories = ["no-std", "wasm"]
 keywords = ["webassembly", "wasm"]
-repository = "https://github.com/bytecodealliance/wasi"
+repository = "https://github.com/bytecodealliance/wasi-rs"
 readme = "README.md"
 documentation = "https://docs.rs/wasi"
 


### PR DESCRIPTION
As discussed in #88, rename the repository from `wasi` to `wasi-rs`.

Fixes #88.